### PR TITLE
Including `FILE_FLAG_BACKUP_SEMANTICS` in calls to `CreateFile` (Windows only)

### DIFF
--- a/lib/file/file_windows.go
+++ b/lib/file/file_windows.go
@@ -61,7 +61,7 @@ func OpenFile(path string, mode int, perm os.FileMode) (*os.File, error) {
 	default:
 		createmode = syscall.OPEN_EXISTING
 	}
-	h, e := syscall.CreateFile(pathp, access, sharemode, nil, createmode, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	h, e := syscall.CreateFile(pathp, access, sharemode, nil, createmode, syscall.FILE_ATTRIBUTE_NORMAL|syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
 	if e != nil {
 		return nil, e
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

This change enables `rclone` to read/write from/to files/directories in situations where:

* The existing security context has `SeBackupPrivilege` and/or `SeRestorePrivilege` delegated ***and*** enabled\*.
* The existing security context _does not_ have explicit access to the files/directories in question.

_Note:_ This is an advanced use option. It will have absolutely no impact in most cases. For more information, please see the following:

* https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
* https://learn.microsoft.com/en-us/windows/win32/secauthz/privilege-constants (see: `SE_BACKUP_NAME` and `SE_RESTORE_NAME`)

#### Was the change discussed in an issue or in the forum before?

* https://forum.rclone.org/t/rclone-sebackupprivilege-file-flag-backup-semantics/45339
* https://github.com/rclone/rclone/pull/7877

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)


\* At this time, `rclone` does not have the ability to enable these token privileges and this PR does not include that functionality.